### PR TITLE
[#122183539] Visibility of important platform metrics

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -5,6 +5,7 @@ templates:
   grafana_ctl: bin/grafana_ctl
   post-start: bin/post-start
   create-update-datasources.erb: bin/create-update-datasources
+  create-update-dashboards.erb: bin/create-update-dashboards
   config.ini.erb: config/config.ini
   ssl.key.erb: config/ssl.key
   ssl.crt.erb: config/ssl.crt
@@ -157,6 +158,14 @@ properties:
         user: admin
         password: admin123
         database_name: metrics
+
+  grafana.dashboards:
+    description: |
+      List of grafana dasboards, converted to YAML
+    example: |
+      - name: frontend (without extension)
+        content: <minified JSON content>
+    default: []
 
   grafana.auth.proxy.enabled:
     description: "Handle authentication in a http reverse proxy"

--- a/jobs/grafana/templates/config.ini.erb
+++ b/jobs/grafana/templates/config.ini.erb
@@ -270,5 +270,5 @@ auto_sign_up = <%= p("grafana.auth.proxy.auto_sign_up") %>
 
 ;#################################### Dashboard JSON files ##########################
 [dashboards.json]
-;enabled = false
-;path = /var/lib/grafana/dashboards
+enabled = true
+path = /var/vcap/store/grafana/dashboards

--- a/jobs/grafana/templates/create-update-dashboards.erb
+++ b/jobs/grafana/templates/create-update-dashboards.erb
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+DASHBOARDS_DIR="/var/vcap/store/grafana/dashboards"
+LOG_DIR=/var/vcap/sys/log/grafana
+
+exec &>> ${LOG_DIR}/create-update-dashboards.log
+
+echo Create ${DASHBOARDS_DIR} directory
+mkdir -p ${DASHBOARDS_DIR}
+
+echo Delete old dashboards from ${DASHBOARDS_DIR}
+rm -f ${DASHBOARDS_DIR}/*
+
+<%
+  dashboards = p("grafana.dashboards")
+%>
+
+<% dashboards.each do |dashboard| %>
+dashboard_file="${DASHBOARDS_DIR}/<%= dashboard['name'] %>.json"
+
+echo Create ${dashboard_file}
+
+cat > "${dashboard_file}" <<'EOF'
+<%= dashboard['content'] %>
+EOF
+<% end %>
+
+<% if dashboards.empty? then %>
+echo "No automatic dashboard creation requested"
+<% end %>

--- a/jobs/grafana/templates/post-start
+++ b/jobs/grafana/templates/post-start
@@ -2,3 +2,6 @@
 
 echo "[$(date)] Calling 'create-update-datasources' ..."
 $(dirname $0)/create-update-datasources
+
+echo "[$(date)] Calling 'create-update-dashboards' ..."
+$(dirname $0)/create-update-dashboards


### PR DESCRIPTION
## What

[#122183539 - Visibility of important platform metrics](https://www.pivotaltracker.com/story/show/122183539)

We want to be able to deploy Grafana with dashboard configuration files (JSON files) supplied via the manifest. This will allow us to keep this release generic and change dashboards more easily.

The changes introduced enable dashboard configuration and add a post-start hook to take minified JSON from manifest properties and put them into files.

## How to review

* Checkout branch `DELETE_ME_visibility-of-metrics-122183539-minify` of paas-cf and run a deploy. This only adds the new version of this release and confirms it can be upgraded independently without breaking anything.
* Use Bosh SSH to log into the Grahite VM and confirm the `/var/vcap/store/grafana/dashboards` folder exists. This confirms the release was uploaded and successfully ran the post-start script.
* Deploy using branch `visibility-of-metrics-122183539-minify` of paas-cf. This will generate a manifest containing the necessary JSON.
* Check in Grafana for a dashboard called 'User Impact'. The Grafana URL is revealed with `make dev showenv`.
* Delete the remote branch `DELETE_ME_visibility-of-metrics-122183539-minify`

The review of the actual content of the dashboard is covered by [the corresponding pull request in the paas-cf repository](https://github.com/alphagov/paas-cf/pull/351).

## Who

Anyone but @saliceti @combor or me